### PR TITLE
Reviewer Matt - Add ralf-libs-dbg as dependency of ralf-dbg

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Package: ralf-dbg
 Architecture: any
 Section: debug
 Priority: extra
-Depends: ralf (= ${binary:Version}), gdb
+Depends: ralf (= ${binary:Version}), ralf-libs-dbg (= ${binary:Version}), gdb
 Description: Debugging symbols for ralf
 
 Package: ralf-libs


### PR DESCRIPTION
Simple change to ensure we have all the debugging symbols for debugging.
