### PR TITLE
Reviewer Matt - Add chronos-dbg dependency to ralf-dbg

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Package: ralf-dbg
 Architecture: any
 Section: debug
 Priority: extra
-Depends: ralf (= ${binary:Version}), ralf-libs-dbg (= ${binary:Version}), gdb
+Depends: ralf (= ${binary:Version}), ralf-libs-dbg (= ${binary:Version}), gdb, chronos-dbg
 Description: Debugging symbols for ralf
 
 Package: ralf-libs


### PR DESCRIPTION
Make sure we install Chronos debug symbols on a debug machine.
