### PR TITLE
[Reviewer: Andy] Option handling to support IPv6 similar to Sprout/Homestead

### DIFF
--- a/debian/ralf.init.d
+++ b/debian/ralf.init.d
@@ -135,6 +135,7 @@ do_start()
         echo 0 > /proc/sys/kernel/yama/ptrace_scope
         get_settings
         DAEMON_ARGS="--localhost $local_ip
+                     --http $local_ip
                      --http-threads $num_http_threads
                      -a $log_directory
                      -F $log_directory

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -286,7 +286,7 @@ int main(int argc, char**argv)
   SessionStore* store = new SessionStore(mstore);
   BillingControllerConfig* cfg = new BillingControllerConfig();
   PeerMessageSenderFactory* factory = new PeerMessageSenderFactory(options.billing_realm);
-  ChronosConnection* timer_conn = new ChronosConnection("localhost:7253", "localhost:" + std::to_string(options.http_port));
+  ChronosConnection* timer_conn = new ChronosConnection("localhost:7253", options.http_address + ":" + std::to_string(options.http_port));
   cfg->mgr = new SessionManager(store, dict, factory, timer_conn, diameter_stack);
 
   HttpStack* http_stack = HttpStack::get_instance();


### PR DESCRIPTION
Andy, while configuring a Clearwater system for IPv6 I found these changes to be necessary for Ralf to communicate with Sprout and Chronos (timer notifications). 
