### PR TITLE
[Reviewer: Rob] Provide local IP address to bind HTTP to, rather than binding to 0.0.0.0...

### DIFF
--- a/debian/ralf.init.d
+++ b/debian/ralf.init.d
@@ -135,6 +135,7 @@ do_start()
         echo 0 > /proc/sys/kernel/yama/ptrace_scope
         get_settings
         DAEMON_ARGS="--localhost $local_ip
+                     --http $local_ip
                      --http-threads $num_http_threads
                      -a $log_directory
                      -F $log_directory


### PR DESCRIPTION
... followed by 127.0.0.1 (which fails)

This fixes the discussed issue where the second bind fails so ralf never starts up.  I've live-tested (and run the UTs, but they're not actually affected by this).

Matt
