### PR TITLE
Quit with an error if cluster_settings is not valid

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -340,7 +340,7 @@ int main(int argc, char**argv)
 
   if (!(mstore->has_servers()))
   {
-    LOG_ERROR("cluster_settings file does not contain a valid set of servers");
+    LOG_ERROR("./cluster_settings file does not contain a valid set of servers");
     return 1;
   };
 


### PR DESCRIPTION
Same fix as https://github.com/Metaswitch/sprout/pull/810. No testing yet, but I'll:
- make sure Ralf can start up normally
- blank out cluster_settings, restart Ralf and check for an error log
- blank out cluster_settings, SIGHUP Ralf and check for an error log
- delete cluster_settings, restart Ralf and check for an error log
