### PR TITLE
Protect against bad config

### DIFF
--- a/debian/ralf.init.d
+++ b/debian/ralf.init.d
@@ -89,7 +89,7 @@ get_settings()
   [ -f /etc/clearwater/cluster_settings ] || echo "servers=$local_ip:11211" > /etc/clearwater/cluster_settings
 
   # If the remote cluster settings file exists then start sprout with geo-redundancy enabled
-  [ -f /etc/clearwater/remote_cluster_settings ] && remote_memstore_arg="--remote-memstore /etc/clearwater/remote_cluster_settings"
+  [ -f /etc/clearwater/remote_cluster_settings ] && remote_memstore_arg="--remote-memstore=/etc/clearwater/remote_cluster_settings"
 
   # Set up defaults for user settings then pull in any overrides.
   log_level=2
@@ -107,10 +107,10 @@ get_settings()
   # Set the destination realm correctly
   if [ ! -z $billing_realm ]
   then
-    billing_realm="--billing-realm $billing_realm"
+    billing_realm="--billing-realm=$billing_realm"
   elif [ ! -z $home_domain ]
   then
-    billing_realm="--billing-realm $home_domain"
+    billing_realm="--billing-realm=$home_domain"
   fi
 
   # Enable SNMP alarms if informsink(s) are configured
@@ -140,15 +140,15 @@ do_start()
         # enable gdb to dump a parent homestead process's stack
         echo 0 > /proc/sys/kernel/yama/ptrace_scope
         get_settings
-        DAEMON_ARGS="--localhost $local_ip
-                     --http $local_ip
-                     --http-threads $num_http_threads
-                     -a $log_directory
-                     -F $log_directory
-                     -L $log_level
+        DAEMON_ARGS="--localhost=$local_ip
+                     --http=$local_ip
+                     --http-threads=$num_http_threads
+                     --access-log=$log_directory
+                     --log-file=$log_directory
+                     --log-level=$log_level
                      $billing_realm
                      $alarms_enabled_arg
-                     --sas $sas_server,$NAME@$public_hostname"
+                     --sas=$sas_server,$NAME@$public_hostname"
 
         start-stop-daemon --start --quiet --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON --chuid $NAME --chdir $HOME -- $DAEMON_ARGS \
                 || return 2

--- a/ralf.root/usr/share/clearwater/infrastructure/scripts/ralf
+++ b/ralf.root/usr/share/clearwater/infrastructure/scripts/ralf
@@ -50,7 +50,7 @@ if [[ -z "$identity" ]];
 then
     if [[ -z "$public_hostname" ]];
     then
-        echo "Must have a public_hostname set in /etc/clearwater/config" >&2
+        echo "ERROR: must have a public_hostname set in /etc/clearwater/config" >&2
         exit 1
     fi
     identity=$public_hostname
@@ -58,7 +58,7 @@ fi
 
 if [[ -z "$ralf_hostname" ]];
 then
-    echo "Must have a ralf_hostname set in /etc/clearwater/config" >&2
+    echo "ERROR: must have a ralf_hostname set in /etc/clearwater/config" >&2
     exit 1
 fi
 

--- a/ralf.root/usr/share/clearwater/infrastructure/scripts/ralf
+++ b/ralf.root/usr/share/clearwater/infrastructure/scripts/ralf
@@ -48,7 +48,18 @@ acl_required=false
 
 if [[ -z "$identity" ]];
 then
+    if [[ -z "$public_hostname" ]];
+    then
+        echo "Must have a public_hostname set in /etc/clearwater/config" >&2
+        exit 1
+    fi
     identity=$public_hostname
+fi
+
+if [[ -z "$ralf_hostname" ]];
+then
+    echo "Must have a ralf_hostname set in /etc/clearwater/config" >&2
+    exit 1
 fi
 
 # Strip any characters not valid in an FQDN out of ralf_hostname (for

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -333,6 +333,17 @@ int main(int argc, char**argv)
     return 1;
   }
 
+  MemcachedStore* mstore = new MemcachedStore(false, 
+                                              "./cluster_settings",
+                                              memcached_comm_monitor,
+                                              vbucket_alarm);
+
+  if (!(mstore->has_servers()))
+  {
+    LOG_ERROR("cluster_settings file does not contain a valid set of servers");
+    return 1;
+  };
+
   AccessLogger* access_logger = NULL;
   if (options.access_log_enabled)
   {
@@ -381,10 +392,6 @@ int main(int argc, char**argv)
                                         dict->RF);
   diameter_stack->start();
 
-  MemcachedStore* mstore = new MemcachedStore(false, 
-                                              "./cluster_settings",
-                                              memcached_comm_monitor,
-                                              vbucket_alarm);
   SessionStore* store = new SessionStore(mstore);
   BillingHandlerConfig* cfg = new BillingHandlerConfig();
   PeerMessageSenderFactory* factory = new PeerMessageSenderFactory(options.billing_realm);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -340,7 +340,7 @@ int main(int argc, char**argv)
 
   if (!(mstore->has_servers()))
   {
-    LOG_ERROR("cluster_settings file does not contain a valid set of servers");
+    LOG_ERROR("./cluster_settings file does not contain a valid set of servers");
     return 1;
   };
 


### PR DESCRIPTION
Fixes #107.

Tested the init.d changes by:
* checking that Ralf starts up normally
* checking the debug logs to confirm the startup options were recognised

```
15-12-2014 22:44:11.199 UTC Status main.cpp:319: Log level set to 5
15-12-2014 22:44:11.200 UTC Info main.cpp:329: Command-line options were: /usr/share/clearwater/bin/ralf --localhost=10.249.61.134 --http=10.249.61.134 --http-threads=50 --access-log=/var/log/ralf --log-file=/var/log/ralf --log-level=5 --billing-realm=example.com --sas=0.0.0.0,ralf@10.249.61.134 
15-12-2014 22:44:11.200 UTC Info main.cpp:167: Local host: 10.249.61.134
15-12-2014 22:44:11.200 UTC Info main.cpp:177: HTTP address: 10.249.61.134
15-12-2014 22:44:11.200 UTC Info main.cpp:203: HTTP threads: 50
15-12-2014 22:44:11.200 UTC Info main.cpp:218: Access log: /var/log/ralf
15-12-2014 22:44:11.200 UTC Info main.cpp:208: Billing realm: example.com
15-12-2014 22:44:11.200 UTC Info main.cpp:192: SAS set to 0.0.0.0
```

(I didn't retest after merging in the DNS server command-line option, but I don't think that invalidates my testing.)

Tested the infrastructure/scripts/ralf change by installing with ralf_hostname commented out:

```
Selecting previously unselected package ralf.
(Reading database ... 48564 files and directories currently installed.)
Unpacking ralf (from ralf_1.0-141215.223033_amd64.deb) ...
Setting up ralf (1.0-141215.223033) ...
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US)
Must have a ralf_hostname set in /etc/clearwater/config
dpkg: error processing ralf (--install):
 subprocess installed post-installation script returned error exit status 1
Processing triggers for ureadahead ...
Errors were encountered while processing:
 ralf
root@ip-10-249-61-134:~# 
```

(though I subsequently added ERROR: in front of the error to make it more obvious)

This has the https://github.com/Metaswitch/ralf/pull/112 commits included, so just ignore the main.cpp changes.