### PR TITLE
Unit test needs to link libdl when built using Ubuntu 14.04's tools chain (gcc 4.8.2)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Homepage: http://projectclearwater.org/
 Package: ralf
 Architecture: any
 # Ralf has a dependency on gnutls-bin because it uses the generic_create_diameterconf script in clearwater-infrastructure - we don't want to make this a clearwater-infrastructure dependency as that will pull it in unnecessarily on sprout/bono/homer.
-Depends: clearwater-infrastructure, clearwater-tcp-scalability, clearwater-log-cleanup, ralf-libs, chronos, libsctp1, libboost-regex1.46.1, libzmq3, clearwater-memcached, gnutls-bin, clearwater-socket-factory, libboost-filesystem1.46.1
+Depends: clearwater-infrastructure, clearwater-tcp-scalability, clearwater-log-cleanup, ralf-libs, chronos, libsctp1, libboost-regex-dev ( >= 1.46.1), libzmq3, clearwater-memcached, gnutls-bin, clearwater-socket-factory, libboost-filesystem-dev ( >= 1.46.1)
 Suggests: ralf-dbg, clearwater-snmp-handler-alarm
 Description: ralf, the Clearwater CTF
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -128,7 +128,7 @@ LDFLAGS += -lzmq \
 LDFLAGS_TEST += -Wl,-rpath=$(ROOT)/usr/lib
 
 # Test build also uses libcurl (to verify HttpStack operation)
-LDFLAGS_TEST += -lcurl
+LDFLAGS_TEST += -lcurl -ldl
 
 # Now the GMock / GTest boilerplate.
 GTEST_HEADERS := $(GTEST_DIR)/include/gtest/*.h \


### PR DESCRIPTION
The boost dependencies are too specific to Ubuntu 12.04 so I modified them so as to be compatible with later versions of boost; specifically the version that's part of Ubuntu 14.04. These dependency changes have been incorporated into a build and have been run through system test's regression suite.

Also, the unit tests would not run on Ubuntu 14.04 with specifically linking against libdl, so that has been added to the unit test ld flags. With this option the unit tests run as expected and has no deleterious affect in an Ubuntu 12.04 build environment.
