### PR TITLE
[Reviewer: Ellie] 14.04 dependency fixes

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Homepage: http://projectclearwater.org/
 Package: ralf
 Architecture: any
 # Ralf has a dependency on gnutls-bin because it uses the generic_create_diameterconf script in clearwater-infrastructure - we don't want to make this a clearwater-infrastructure dependency as that will pull it in unnecessarily on sprout/bono/homer.
-Depends: clearwater-infrastructure, clearwater-tcp-scalability, clearwater-log-cleanup, ralf-libs, chronos, libsctp1, libboost-regex1.46.1, libzmq3, clearwater-memcached, gnutls-bin, clearwater-socket-factory, libboost-filesystem1.46.1
+Depends: clearwater-infrastructure, clearwater-tcp-scalability, clearwater-log-cleanup, ralf-libs, chronos, libsctp1, libboost-regex1.54.0, libzmq3, clearwater-memcached, gnutls-bin, clearwater-socket-factory, libboost-filesystem1.54.0
 Suggests: ralf-dbg, clearwater-snmp-handler-alarm
 Description: ralf, the Clearwater CTF
 

--- a/mk/libmemcached.mk
+++ b/mk/libmemcached.mk
@@ -26,9 +26,10 @@ libmemcached_test: libevent ${LIBMEM_MAKEFILE}
 
 libmemcached_clean: ${LIBMEM_MAKEFILE}
 	${MAKE} -C ${LIBMEM_DIR} clean
+	rm ${LIBMEM_CONFIGURE}
 
 libmemcached_distclean: ${LIBMEM_MAKEFILE}
 	${MAKE} -C ${LIBMEM_DIR} distclean
-
+	rm ${LIBMEM_CONFIGURE}
 
 .PHONY: libmemcached libmemcached_test libmemcached_clean libmemcached_distclean


### PR DESCRIPTION
This:
* fixes up the Boost dependencies, like everywhere else
* makes the libmemcached Makefile change discussed in https://github.com/Metaswitch/libmemcached-upstream/pull/6

I've tested the latter by running `make clean`, checking that `modules/libmemcached/configure` was removed, and that a subsequent `make` rebuilt it and everything that depends on it.

If you're happy with that, I'll make the same change (without review) to the other libmemcached.mk files elsewhere.