### PR TITLE
[No reviewer] Don't load remote memcached plugin if there's no remote site

### DIFF
--- a/ralf.root/usr/share/clearwater/clearwater-cluster-manager/plugins/ralf_remote_memcached_plugin.py
+++ b/ralf.root/usr/share/clearwater/clearwater-cluster-manager/plugins/ralf_remote_memcached_plugin.py
@@ -82,4 +82,5 @@ class RalfRemoteMemcachedPlugin(SynchroniserPluginBase):
 
 
 def load_as_plugin(ip, local_site, remote_site):
-    return RalfRemoteMemcachedPlugin(ip, local_site, remote_site)
+    if remote_site != "":
+        return RalfRemoteMemcachedPlugin(ip, local_site, remote_site)


### PR DESCRIPTION
Identical to corresponding Sprout change.