### PR TITLE
[Reviewer: Andy] Don't fail infrastructure scripts

### DIFF
--- a/ralf.root/usr/share/clearwater/infrastructure/scripts/ralf
+++ b/ralf.root/usr/share/clearwater/infrastructure/scripts/ralf
@@ -50,16 +50,16 @@ if [[ -z "$identity" ]];
 then
     if [[ -z "$public_hostname" ]];
     then
-        echo "ERROR: must have a public_hostname set in /etc/clearwater/config" >&2
-        exit 1
+        echo "No public_hostname set in /etc/clearwater/local_config" >&2
+        exit
     fi
     identity=$public_hostname
 fi
 
 if [[ -z "$ralf_hostname" ]];
 then
-    echo "ERROR: must have a ralf_hostname set in /etc/clearwater/config" >&2
-    exit 1
+    echo "No ralf_hostname set in /etc/clearwater/shared_config" >&2
+    exit
 fi
 
 # Strip any characters not valid in an FQDN out of ralf_hostname (for


### PR DESCRIPTION
We can't currently install Ralf using etcd because ralf_hostname isn't set yet.  I've coded the same fix as you applied to Homestead at https://github.com/Metaswitch/homestead/commit/cb3ce289e536d1fa83f192d9ece1c008315c47e2.

Please can you have a think about whether there are any other repos that need fixing up in this way?  (I haven't hit any yet.)