### PR TITLE
[Reviewer: Andy] Don't crash if /var/lib/ralf/ralf.conf missing

### DIFF
--- a/include/ralf_pd_definitions.h
+++ b/include/ralf_pd_definitions.h
@@ -128,4 +128,16 @@ const static PDLog2<const char*, int> CL_RALF_HTTP_STOP_ERROR
   "None."
 );
 
+static const PDLog2<const char*, int> CL_RALF_DIAMETER_INIT_FAIL
+(
+  PDLogBase::CL_HOMESTEAD_ID + 7,
+  PDLOG_ERR,
+  "Fatal - Failed to initialize Diameter stack in function %s with error %d.",
+  "The Diameter interface could not be initialized or encountered an "
+  "error while running.",
+  "The application will exit and restart until the problem is fixed.",
+  "(1). Check the configuration for the Diameter destination hosts. "
+  "(2). Check the connectivity to the Diameter host using Wireshark."
+);
+
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -571,14 +571,25 @@ int main(int argc, char**argv)
 
   Diameter::Stack* diameter_stack = Diameter::Stack::get_instance();
   Rf::Dictionary* dict = NULL;
-  diameter_stack->initialize();
-  diameter_stack->configure(options.diameter_conf,
-                            exception_handler,
-                            cdf_comm_monitor);
-  dict = new Rf::Dictionary();
-  diameter_stack->advertize_application(Diameter::Dictionary::Application::ACCT,
-                                        dict->RF);
-  diameter_stack->start();
+
+  try
+  {
+    diameter_stack->initialize();
+    diameter_stack->configure(options.diameter_conf,
+                              exception_handler,
+                              cdf_comm_monitor);
+    dict = new Rf::Dictionary();
+    diameter_stack->advertize_application(Diameter::Dictionary::Application::ACCT,
+                                          dict->RF);
+    diameter_stack->start();
+  }
+  catch (Diameter::Stack::Exception& e)
+  {
+    CL_RALF_DIAMETER_INIT_FAIL.log(e._func, e._rc);
+    closelog();
+    LOG_ERROR("Failed to initialize Diameter stack - function %s, rc %d", e._func, e._rc);
+    exit(2);
+  }
 
   SessionStore::SerializerDeserializer* serializer;
   std::vector<SessionStore::SerializerDeserializer*> deserializers;


### PR DESCRIPTION
Without this fix, Ralf cyclically crashes (and dumps core) when /var/lib/ralf/ralf.conf is missing (as it will be before configuration has synchronized).  This fix means that it logs in an error and exits cleanly.  This means we don't kill the disk with core files.