### PR TITLE
Reviewer MIRW: Set default blacklist durations

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -461,6 +461,8 @@ int main(int argc, char**argv)
   options.init_token_rate = 100.0;
   options.min_token_rate = 10.0;
   options.exception_max_ttl = 600;
+  options.http_blacklist_duration = HttpResolver::DEFAULT_BLACKLIST_DURATION;
+  options.diameter_blacklist_duration = DiameterResolver::DEFAULT_BLACKLIST_DURATION;
 
   boost::filesystem::path p = argv[0];
   // Copy the filename to a string so that we can be sure of its lifespan -


### PR DESCRIPTION
Matt, along with https://github.com/Metaswitch/homestead/pull/231 and https://github.com/Metaswitch/memento/pull/82, I think these are all the blacklist duration defaults that need setting. They're already set correctly in Sprout. Do you agree?