### PR TITLE
Reviewer AMC: Keep data around in memcached for longer

### DIFF
--- a/src/sessionstore.cpp
+++ b/src/sessionstore.cpp
@@ -125,7 +125,7 @@ bool SessionStore::set_session_data(const std::string& call_id,
                                           key,
                                           data,
                                           session->_cas,
-                                          session->session_refresh_time,
+                                          2 * session->session_refresh_time,
                                           trail);
   TRC_DEBUG("Store returned %d", status);
 


### PR DESCRIPTION
As discussed. We've seen race conditions under stress where the data gets erased too early.