### PR TITLE
Switch from Python version of bracket_ipv6_address to C++ version

### DIFF
--- a/ralf.root/usr/share/clearwater/bin/poll_ralf.sh
+++ b/ralf.root/usr/share/clearwater/bin/poll_ralf.sh
@@ -35,6 +35,6 @@
 # as those licenses appear in the file LICENSE-OPENSSL.
 
 . /etc/clearwater/config
-http_ip=$(/usr/share/clearwater/bin/bracket_ipv6_address.py $local_ip)
+http_ip=$(/usr/share/clearwater/bin/bracket-ipv6-address $local_ip)
 /usr/share/clearwater/bin/poll-http $http_ip:10888
 exit $?


### PR DESCRIPTION
Same as https://github.com/Metaswitch/clearwater-infrastructure/pull/332, but for this repo.