### PR TITLE
[Reviewer: AJH] Split storage configuration on Ralf

### DIFF
--- a/debian/ralf.init.d
+++ b/debian/ralf.init.d
@@ -135,6 +135,8 @@ get_daemon_args()
         [ -z "$cdf_identity" ] || billing_peer_arg="--billing-peer=$cdf_identity"
         [ -z $signaling_namespace ] || namespace_prefix="ip netns exec $signaling_namespace"
         [ -z "$local_site_name" ] || local_site_name_arg="--local-site-name=$local_site_name"
+        [ -z "$chronos_hostname" ] || chronos_hostname_arg="--chronos-hostname=$chronos_hostname"
+        [ -z "$ralf_hostname" ] || ralf_hostname_arg="--ralf-hostname=$chronos_hostname"
 
         DAEMON_ARGS="--localhost=$local_ip
                      $local_site_name_arg
@@ -145,6 +147,8 @@ get_daemon_args()
                      --dns-server=$signaling_dns_server
                      --log-file=$log_directory
                      --log-level=$log_level
+                     $chronos_hostname_arg
+                     $ralf_hostname_arg
                      $billing_realm_arg
                      $billing_peer_arg
                      $target_latency_us_arg

--- a/debian/ralf.init.d
+++ b/debian/ralf.init.d
@@ -136,7 +136,7 @@ get_daemon_args()
         [ -z $signaling_namespace ] || namespace_prefix="ip netns exec $signaling_namespace"
         [ -z "$local_site_name" ] || local_site_name_arg="--local-site-name=$local_site_name"
         [ -z "$chronos_hostname" ] || chronos_hostname_arg="--chronos-hostname=$chronos_hostname"
-        [ -z "$ralf_hostname" ] || ralf_hostname_arg="--ralf-hostname=$chronos_hostname"
+        [ -z "$ralf_hostname" ] || ralf_hostname_arg="--ralf-hostname=$ralf_hostname"
 
         DAEMON_ARGS="--localhost=$local_ip
                      $local_site_name_arg

--- a/ralf.root/usr/share/clearwater/bin/poll_ralf.sh
+++ b/ralf.root/usr/share/clearwater/bin/poll_ralf.sh
@@ -35,6 +35,6 @@
 # as those licenses appear in the file LICENSE-OPENSSL.
 
 . /etc/clearwater/config
-http_ip=$(/usr/share/clearwater/bin/bracket_ipv6_address.py $local_ip)
+http_ip=$(/usr/share/clearwater/bin/bracket-ipv6-address $local_ip)
 /usr/share/clearwater/bin/poll-http $http_ip:10888
 exit $?

--- a/ralf.root/usr/share/clearwater/infrastructure/scripts/ralf.monit
+++ b/ralf.root/usr/share/clearwater/infrastructure/scripts/ralf.monit
@@ -45,18 +45,18 @@ check process ralf_process with pidfile /var/run/ralf/ralf.pid
   group ralf 
 
   # The start, stop and restart commands are linked to alarms
-  start program = "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 2000.3; /etc/init.d/ralf start'"
-  stop program = "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 2000.3; /etc/init.d/ralf stop'"
-  restart program = "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 2000.3; /etc/init.d/ralf restart'"
+  start program = "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 2000.3; /etc/init.d/ralf start'"
+  stop program = "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 2000.3; /etc/init.d/ralf stop'"
+  restart program = "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 2000.3; /etc/init.d/ralf restart'"
 
   # Check the service's resource usage, and abort the process if it's too high. This will
   # generate a core file and trigger diagnostics collection.
-  if memory > 80% for 6 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 2000.3; /etc/init.d/ralf abort'"
+  if memory > 80% for 6 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 2000.3; /etc/init.d/ralf abort'"
 
   # Clear any alarms if the process has been running for 30 seconds
   if uptime < 30 seconds
      then exec "/bin/true"
-     else if succeeded then exec "/usr/share/clearwater/bin/issue_alarm.py monit 2000.1"
+     else if succeeded then exec "/usr/share/clearwater/bin/issue-alarm monit 2000.1"
 
 # Check the HTTP interface. This depends on the Ralf process (and so won't run
 # unless the Ralf process is running)
@@ -65,7 +65,7 @@ check program poll_ralf with path "/usr/share/clearwater/bin/poll_ralf.sh"
   depends on ralf_process
 
   # Aborting generates a core file and triggers diagnostic collection.
-  if status != 0 for 2 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 2000.3; /etc/init.d/ralf abort'"
+  if status != 0 for 2 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 2000.3; /etc/init.d/ralf abort'"
 EOF
 chmod 0644 /etc/monit/conf.d/ralf.monit
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -209,10 +209,12 @@ void usage(void)
        "     --astaire-blacklist-duration <secs>\n"
        "                            The amount of time to blacklist an Astaire node when it is unresponsive.\n"
        "     --chronos-hostname <hostname>\n"
-       "                            The hostname of the remote Chronos cluster to use.\n"
-       "     --ralf-hostname <hostname>\n"
-       "                            The hostname of the cluster to which this Ralf is a member for the\n"
-       "                            remote Chronos cluster to use.\n"
+       "                            The hostname of the remote Chronos cluster to use. If unset, the default\n"
+       "                            is to use localhost, using localhost as the callback URL.\n"
+       "     --ralf-hostname <hostname:port>\n"
+       "                            The hostname and port of the cluster of Ralf nodes to which this Ralf is\n"
+       "                            a member. The port should be the HTTP port the nodes are listening on.\n"
+       "                            This is used to form the callback URL for the Chronos cluser.\n"
        "     --pidfile=<filename>   Write pidfile\n"
        " -h, --help                 Show this help screen\n"
       );
@@ -748,8 +750,9 @@ int main(int argc, char**argv)
 
   if (options.chronos_hostname == "" || options.ralf_hostname == "")
   {
-    // We want Chronos to call back to its local Ralf instance so that we can
-    // handle Ralfs failing without missing timers.
+    // If we are using a local chronos cluster, we want Chronos to call back to
+    // its local Ralf instance so that we can handle Ralfs failing without missing
+    // timers.
     chronos_service = "127.0.0.1:7253";
     http_af = AF_INET;
 
@@ -765,10 +768,8 @@ int main(int argc, char**argv)
   else
   {
     chronos_service = options.chronos_hostname + ":7253";
-
     http_af = is_ipv6(options.chronos_hostname) ? AF_INET6 : AF_INET;
-
-    chronos_callback_addr = options.ralf_hostname + ":" + port_str;
+    chronos_callback_addr = options.ralf_hostname;
   }
 
   // Create a connection to Chronos.  This requires an HttpResolver.


### PR DESCRIPTION
Allow the Chronos cluster to be configured and pass the Ralf hostname
into the cluster as a callback URL.

This, along with the split-clusters work, allows Ralf to use an external storage node.
