### PR TITLE
[Reviewer AJH] Optionally route sas traffic via signaling namespace

### DIFF
--- a/debian/ralf.init.d
+++ b/debian/ralf.init.d
@@ -133,6 +133,8 @@ get_daemon_args()
           billing_realm_arg="--billing-realm=$home_domain"
         fi
 
+        [ "$sas_use_signaling_interface" != "Y" ] || sas_signaling_if_arg="--sas-use-signaling-interface"
+
         [ -z "$target_latency_us" ] || target_latency_us_arg="--target-latency-us=$target_latency_us"
         [ -z "$max_tokens" ] || max_tokens_arg="--max-tokens=$max_tokens"
         [ -z "$init_token_rate" ] || init_token_rate_arg="--init-token-rate=$init_token_rate"
@@ -155,6 +157,7 @@ get_daemon_args()
                      $init_token_rate_arg
                      $min_token_rate_arg
                      $exception_max_ttl_arg
+                     $sas_signaling_if_arg
                      --sas=$sas_server,$NAME@$public_hostname"
 
         [ "$http_blacklist_duration" = "" ]     || DAEMON_ARGS="$DAEMON_ARGS --http-blacklist-duration=$http_blacklist_duration"


### PR DESCRIPTION
This change adds support for a config parameter to control whether SAS traffic is routed via the signaling network instead of the (default) management network.  

Tested using tcpdump to confirm that the signaling namespace is used for SAS traffic iff this parameter is set to "Y".

Associated PRs for ralf, homestead and readthedocs will be linked below