### PR TITLE
[Reviwer: EM] Create a (de)serializer before writing to each memory store

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -749,6 +749,18 @@ int main(int argc, char**argv)
        it != remote_session_stores_locations.end();
        ++it)
   {
+    if (options.memcached_write_format == MemcachedWriteFormat::JSON)
+    {
+      serializer = new SessionStore::JsonSerializerDeserializer();
+    }
+    else
+    {
+      serializer = new SessionStore::BinarySerializerDeserializer();
+    }
+
+    deserializers.push_back(new SessionStore::JsonSerializerDeserializer());
+    deserializers.push_back(new SessionStore::BinarySerializerDeserializer());
+
     TopologyNeutralMemcachedStore* remote_memstore =
                      new TopologyNeutralMemcachedStore(*it,
                                                        astaire_resolver,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -749,6 +749,9 @@ int main(int argc, char**argv)
        it != remote_session_stores_locations.end();
        ++it)
   {
+    SessionStore::SerializerDeserializer* serializer;
+    std::vector<SessionStore::SerializerDeserializer*> deserializers;
+
     if (options.memcached_write_format == MemcachedWriteFormat::JSON)
     {
       serializer = new SessionStore::JsonSerializerDeserializer();


### PR DESCRIPTION
This stops Ralf crashing when trying to connect to remote memcached stores.