### PR TITLE
[Reviewer: Ellie] Add chronos-ralf-callback-uri option

### DIFF
--- a/debian/ralf.init.d
+++ b/debian/ralf.init.d
@@ -138,6 +138,7 @@ get_daemon_args()
         [ -z $signaling_namespace ] || namespace_prefix="ip netns exec $signaling_namespace"
         [ -z "$local_site_name" ] || local_site_name_arg="--local-site-name=$local_site_name"
         [ -z "$chronos_hostname" ] || chronos_hostname_arg="--chronos-hostname=$chronos_hostname"
+        [ -z "$chronos_ralf_callback_uri" ] || chronos_ralf_callback_uri_arg="--chronos-ralf-callback-uri=$chronos_ralf_callback_uri"
         [ -z "$ralf_hostname" ] || ralf_hostname_arg="--ralf-hostname=$ralf_hostname"
 
         DAEMON_ARGS="--localhost=$local_ip
@@ -150,6 +151,7 @@ get_daemon_args()
                      --log-file=$log_directory
                      --log-level=$log_level
                      $chronos_hostname_arg
+                     $chronos_ralf_callback_uri_arg
                      $ralf_hostname_arg
                      $billing_realm_arg
                      $billing_peer_arg

--- a/debian/ralf.init.d
+++ b/debian/ralf.init.d
@@ -138,7 +138,7 @@ get_daemon_args()
         [ -z $signaling_namespace ] || namespace_prefix="ip netns exec $signaling_namespace"
         [ -z "$local_site_name" ] || local_site_name_arg="--local-site-name=$local_site_name"
         [ -z "$chronos_hostname" ] || chronos_hostname_arg="--chronos-hostname=$chronos_hostname"
-        [ -z "$chronos_ralf_callback_uri" ] || chronos_ralf_callback_uri_arg="--chronos-ralf-callback-uri=$chronos_ralf_callback_uri"
+        [ -z "$ralf_chronos_callback_uri" ] || ralf_chronos_callback_uri_arg="--ralf-chronos-callback-uri=$ralf_chronos_callback_uri"
         [ -z "$ralf_hostname" ] || ralf_hostname_arg="--ralf-hostname=$ralf_hostname"
 
         DAEMON_ARGS="--localhost=$local_ip
@@ -151,7 +151,7 @@ get_daemon_args()
                      --log-file=$log_directory
                      --log-level=$log_level
                      $chronos_hostname_arg
-                     $chronos_ralf_callback_uri_arg
+                     $ralf_chronos_callback_uri_arg
                      $ralf_hostname_arg
                      $billing_realm_arg
                      $billing_peer_arg

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,7 +83,7 @@ enum OptionTypes
   SESSION_STORES,
   DAEMON,
   CHRONOS_HOSTNAME,
-  CHRONOS_RALF_CALLBACK_URI,
+  RALF_CHRONOS_CALLBACK_URI,
   RALF_HOSTNAME
 };
 
@@ -125,7 +125,7 @@ struct options
   bool daemon;
   bool sas_signaling_if;
   std::string chronos_hostname;
-  std::string chronos_ralf_callback_uri;
+  std::string ralf_chronos_callback_uri;
   std::string ralf_hostname;
 };
 
@@ -159,7 +159,7 @@ const static struct option long_opt[] =
   {"daemon",                      no_argument,       NULL, DAEMON},
   {"sas-use-signaling-interface", no_argument,       NULL, SAS_USE_SIGNALING_IF},
   {"chronos-hostname",            required_argument, NULL, CHRONOS_HOSTNAME},
-  {"chronos-ralf-callback-uri",   required_argument, NULL, CHRONOS_RALF_CALLBACK_URI},
+  {"ralf-chronos-callback-uri",   required_argument, NULL, RALF_CHRONOS_CALLBACK_URI},
   {"ralf-hostname",               required_argument, NULL, RALF_HOSTNAME},
   {NULL,                          0,                 NULL, 0},
 };
@@ -222,6 +222,10 @@ void usage(void)
        "     --chronos-hostname <hostname>\n"
        "                            The hostname of the remote Chronos cluster to use. If unset, the default\n"
        "                            is to use localhost, using localhost as the callback URL.\n"
+       "     --ralf-chronos-callback-uri <hostname>\n"
+       "                            The ralf hostname used for Chronos callbacks. If unset the default \n"
+       "                            is to use the ralf-hostname.\n"
+       "                            Ignored if chronos-hostname is not set.\n"
        "     --ralf-hostname <hostname:port>\n"
        "                            The hostname and port of the cluster of Ralf nodes to which this Ralf is\n"
        "                            a member. The port should be the HTTP port the nodes are listening on.\n"
@@ -459,8 +463,8 @@ int init_options(int argc, char**argv, struct options& options)
       options.chronos_hostname = std::string(optarg);
       break;
 
-    case CHRONOS_RALF_CALLBACK_URI:
-      options.chronos_ralf_callback_uri = std::string(optarg);
+    case RALF_CHRONOS_CALLBACK_URI:
+      options.ralf_chronos_callback_uri = std::string(optarg);
       break;
 
     case RALF_HOSTNAME:
@@ -822,9 +826,10 @@ int main(int argc, char**argv)
       http_af = AF_INET6;
     }
 
-    if (options.chronos_ralf_callback_uri != "")
+    if (options.ralf_chronos_callback_uri != "")
     {
-      chronos_callback_addr = options.chronos_ralf_callback_uri;
+      // The callback URI doesn't include the port
+      chronos_callback_addr = options.ralf_chronos_callback_uri + ":" + port_str;
     }
     else
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,6 +83,7 @@ enum OptionTypes
   SESSION_STORES,
   DAEMON,
   CHRONOS_HOSTNAME,
+  CHRONOS_RALF_CALLBACK_URI,
   RALF_HOSTNAME
 };
 
@@ -124,6 +125,7 @@ struct options
   bool daemon;
   bool sas_signaling_if;
   std::string chronos_hostname;
+  std::string chronos_ralf_callback_uri;
   std::string ralf_hostname;
 };
 
@@ -157,6 +159,7 @@ const static struct option long_opt[] =
   {"daemon",                      no_argument,       NULL, DAEMON},
   {"sas-use-signaling-interface", no_argument,       NULL, SAS_USE_SIGNALING_IF},
   {"chronos-hostname",            required_argument, NULL, CHRONOS_HOSTNAME},
+  {"chronos-ralf-callback-uri",   required_argument, NULL, CHRONOS_RALF_CALLBACK_URI},
   {"ralf-hostname",               required_argument, NULL, RALF_HOSTNAME},
   {NULL,                          0,                 NULL, 0},
 };
@@ -454,6 +457,10 @@ int init_options(int argc, char**argv, struct options& options)
 
     case CHRONOS_HOSTNAME:
       options.chronos_hostname = std::string(optarg);
+      break;
+
+    case CHRONOS_RALF_CALLBACK_URI:
+      options.chronos_ralf_callback_uri = std::string(optarg);
       break;
 
     case RALF_HOSTNAME:
@@ -815,7 +822,14 @@ int main(int argc, char**argv)
       http_af = AF_INET6;
     }
 
-    chronos_callback_addr = options.ralf_hostname;
+    if (options.chronos_ralf_callback_uri != "")
+    {
+      chronos_callback_addr = options.chronos_ralf_callback_uri;
+    }
+    else
+    {
+      chronos_callback_addr = options.ralf_hostname;
+    }
   }
 
   // Create a connection to Chronos.  This requires an HttpResolver.


### PR DESCRIPTION
rather than just using the configured ralf hostname for chronos callbacks. This
allows us to configure chronos to always call back to ralfs in the local site

Testing done:
 - live tested