### PR TITLE
[Reviewer: Ellie] Parse for multiple DNS servers in main

### DIFF
--- a/debian/ralf.init.d
+++ b/debian/ralf.init.d
@@ -149,7 +149,7 @@ get_daemon_args()
                      --http=$local_ip
                      --http-threads=$num_http_threads
                      --access-log=$log_directory
-                     --dns-server=$signaling_dns_server
+                     --dns-servers=$signaling_dns_server
                      --log-file=$log_directory
                      --log-level=$log_level
                      $chronos_hostname_arg

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -124,7 +124,7 @@ const static struct option long_opt[] =
 {
   {"localhost",                   required_argument, NULL, 'l'},
   {"diameter-conf",               required_argument, NULL, 'c'},
-  {"dns-server",                  required_argument, NULL, DNS_SERVER},
+  {"dns-servers",                 required_argument, NULL, DNS_SERVER},
   {"http",                        required_argument, NULL, 'H'},
   {"http-threads",                required_argument, NULL, 't'},
   {"billing-realm",               required_argument, NULL, 'b'},
@@ -159,7 +159,7 @@ void usage(void)
        "\n"
        " -l, --localhost <hostname> Specify the local hostname or IP address\n"
        " -c, --diameter-conf <file> File name for Diameter configuration\n"
-       "     --dns-server <server>[,<server2>,<server3>]\n"
+       "     --dns-servers <server>[,<server2>,<server3>]\n"
        "                            IP addresses of the DNS servers to use (defaults to 127.0.0.1)\n"
        " -H, --http <address>[:<port>]\n"
        "                            Set HTTP bind address and port (default: 0.0.0.0:8888)\n"


### PR DESCRIPTION
This is implementing similar function as is in Sprout, to fix https://github.com/Metaswitch/ralf/issues/250 .

Tested live, setting the `signaling_dns_server` option in local_config `1.1.1.1,1.1.2.2`. 
The logs show this being picked up:
```
11-11-2016 14:05:11.641 UTC Status dnscachedresolver.cpp:150: Creating Cached Resolver using servers:
11-11-2016 14:05:11.641 UTC Status dnscachedresolver.cpp:160:     1.1.1.1
11-11-2016 14:05:11.641 UTC Status dnscachedresolver.cpp:160:     1.1.2.2
```

Running `tcpdump net 1.1.0.0/16` showed ralf attempting to contact these two IPs separately for DNS resolution, as below:
```
14:05:55.909428 IP ec2-54-152-83-155.compute-1.amazonaws.com.56405 > 1.1.1.1.domain: 36183+ SRV? _diameter._tcp.cdf.ajl.cw-ngv.com. (51)
14:05:55.909454 IP ec2-54-152-83-155.compute-1.amazonaws.com.56405 > 1.1.1.1.domain: 38537+ SRV? _diameter._sctp.cdf.ajl.cw-ngv.com. (52)
14:05:56.471467 IP ec2-54-152-83-155.compute-1.amazonaws.com.44370 > 1.1.2.2.domain: 38537+ SRV? _diameter._sctp.cdf.ajl.cw-ngv.com. (52)
14:05:56.721820 IP ec2-54-152-83-155.compute-1.amazonaws.com.44370 > 1.1.2.2.domain: 36183+ SRV? _diameter._tcp.cdf.ajl.cw-ngv.com. (51)
```

As the change is only in main.cpp, no UT changes :)