### PR TITLE
[Reviewer: Ellie] better load monitor latency stats

### DIFF
--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -77,8 +77,6 @@ void BillingTask::run()
   }
   else
   {
-    send_http_reply(rc);
-
     if (msg != NULL)
     {
       TRC_DEBUG("Handle the received message");
@@ -88,6 +86,11 @@ void BillingTask::run()
       _sess_mgr->handle(msg);
       msg = NULL;
     }
+
+    // The HTTP reply won't be sent until afer we leave this function, so by
+    // putting this last we ensure that the load monitor will get a sensible
+    // value for the latency
+    send_http_reply(rc);
   }
 
   delete this;


### PR DESCRIPTION
Move send_http_reply to after handling the message so the load monitor latency
accurately reflects the time taken to send the reply

Fixes #58 

**Testing**
Live tested with manual change to add extra latency to ensure that the load monitor is getting the true value of the latency