### PR TITLE
Added the Service-Context-Id AVP to ACRs

### DIFF
--- a/include/rf.h
+++ b/include/rf.h
@@ -49,9 +49,12 @@ namespace Rf {
 
 const std::vector<std::string> VENDORS { "3GPP", "" };
 
-// This will need updating when the version of Spec TS32.299 that we support
-// changes. Currently we support v10.
-const char* const SERV_CONTXT_ID = "MNC.MCC.10.32260@3gpp.org";
+// The service context id will need updating when the version of Spec TS32.299
+// that we support changes - currently v10 is supported. The current format
+// follows what is specified in Chapter 7.1.12. No operator-specific extensions
+// are required, and a full stop is not present in before "MNC" for
+// consistency with other products.
+static const std::string SERVICE_CONTEXT_ID_STR = "MNC.MCC.10.32260@3gpp.org";
 
 class AccountingRecordType {
 public:

--- a/include/rf.h
+++ b/include/rf.h
@@ -49,6 +49,11 @@ namespace Rf {
 
 const std::vector<std::string> VENDORS { "3GPP", "" };
 
+// Do I need to set this to static??
+// This will need updating when the version of Spec TS32.299 that we support
+// changes. Currently we support v10.
+static const std::string SERV_CONTXT_ID = "MNC.MCC.10.32260@3gpp.org";
+
 class AccountingRecordType {
 public:
   AccountingRecordType(int type): _type(type) {};
@@ -71,6 +76,7 @@ public:
   const Diameter::Dictionary::Vendor TGPP;
   const Diameter::Dictionary::Message ACCOUNTING_REQUEST;
   const Diameter::Dictionary::Message ACCOUNTING_RESPONSE;
+  const Diameter::Dictionary::Message SERVICE_CONTEXT_ID;
 };
 
 class AccountingRequest : public Diameter::Message

--- a/include/rf.h
+++ b/include/rf.h
@@ -49,10 +49,9 @@ namespace Rf {
 
 const std::vector<std::string> VENDORS { "3GPP", "" };
 
-// Do I need to set this to static??
 // This will need updating when the version of Spec TS32.299 that we support
 // changes. Currently we support v10.
-static const std::string SERV_CONTXT_ID = "MNC.MCC.10.32260@3gpp.org";
+const char* const SERV_CONTXT_ID = "MNC.MCC.10.32260@3gpp.org";
 
 class AccountingRecordType {
 public:

--- a/include/rf.h
+++ b/include/rf.h
@@ -75,7 +75,7 @@ public:
   const Diameter::Dictionary::Vendor TGPP;
   const Diameter::Dictionary::Message ACCOUNTING_REQUEST;
   const Diameter::Dictionary::Message ACCOUNTING_RESPONSE;
-  const Diameter::Dictionary::Message SERVICE_CONTEXT_ID;
+  const Diameter::Dictionary::AVP SERVICE_CONTEXT_ID;
 };
 
 class AccountingRequest : public Diameter::Message

--- a/src/rf.cpp
+++ b/src/rf.cpp
@@ -89,7 +89,7 @@ AccountingRequest::AccountingRequest(const Dictionary* dict,
 
   Diameter::Dictionary::AVP service_context_dict("Service-Context-Id");
   Diameter::AVP service_context_avp(service_context_dict);
-  add(service_context_avp.val_str(Rf::SERV_CONTXT_ID));
+  add(service_context_avp.val_str(Rf::SERVICE_CONTEXT_ID_STR));
 
   if (contents.GetType() != rapidjson::kObjectType)
   {

--- a/src/rf.cpp
+++ b/src/rf.cpp
@@ -43,7 +43,8 @@ Dictionary::Dictionary() :
   RF("Diameter Base Accounting"),
   TGPP("3GPP"),
   ACCOUNTING_REQUEST("Accounting-Request"),
-  ACCOUNTING_RESPONSE("Accounting-Answer")
+  ACCOUNTING_RESPONSE("Accounting-Answer"),
+  SERVICE_CONTEXT_ID("Service-Context-Id")
 {
 }
 
@@ -85,6 +86,12 @@ AccountingRequest::AccountingRequest(const Dictionary* dict,
   Diameter::Dictionary::AVP record_number_dict("Accounting-Record-Number");
   Diameter::AVP record_number_avp(record_number_dict);
   add(record_number_avp.val_i32(record_number));
+
+  printf("from header: %s", Rf::SERV_CONTXT_ID.c_str());
+
+  Diameter::Dictionary::AVP service_context_dict("Service-Context-Id");
+  Diameter::AVP service_context_avp(service_context_dict);
+  add(service_context_avp.val_str("MNC.MCC.10.32260@3gpp.org"));
 
   if (contents.GetType() != rapidjson::kObjectType)
   {

--- a/src/rf.cpp
+++ b/src/rf.cpp
@@ -87,11 +87,11 @@ AccountingRequest::AccountingRequest(const Dictionary* dict,
   Diameter::AVP record_number_avp(record_number_dict);
   add(record_number_avp.val_i32(record_number));
 
-  printf("from header: %s", Rf::SERV_CONTXT_ID.c_str());
+  printf("\n\nfrom header: %s\n\n", Rf::SERV_CONTXT_ID);
 
   Diameter::Dictionary::AVP service_context_dict("Service-Context-Id");
   Diameter::AVP service_context_avp(service_context_dict);
-  add(service_context_avp.val_str("MNC.MCC.10.32260@3gpp.org"));
+  add(service_context_avp.val_str(Rf::SERV_CONTXT_ID));
 
   if (contents.GetType() != rapidjson::kObjectType)
   {

--- a/src/rf.cpp
+++ b/src/rf.cpp
@@ -87,8 +87,6 @@ AccountingRequest::AccountingRequest(const Dictionary* dict,
   Diameter::AVP record_number_avp(record_number_dict);
   add(record_number_avp.val_i32(record_number));
 
-  printf("\n\nfrom header: %s\n\n", Rf::SERV_CONTXT_ID);
-
   Diameter::Dictionary::AVP service_context_dict("Service-Context-Id");
   Diameter::AVP service_context_avp(service_context_dict);
   add(service_context_avp.val_str(Rf::SERV_CONTXT_ID));

--- a/src/ut/test_rf.cpp
+++ b/src/ut/test_rf.cpp
@@ -118,6 +118,9 @@ TEST_F(RfTest, CreateMessageTest)
   Diameter::Message msg = launder_message(acr);
   acr = Rf::AccountingRequest(msg);
 
+  printf("\n\nhi\n\n");
+  printf("acr: %s", acr.get_session_id().c_str());
+//  printf("sci: %s", acr.begin((Rf::Dictionary*)(acr.dict())->SERVICE_CONTEXT_ID)->val_str().c_str());
   delete body_doc;
 };
 

--- a/src/ut/test_rf.cpp
+++ b/src/ut/test_rf.cpp
@@ -110,7 +110,7 @@ TEST_F(RfTest, CreateMessageTest)
 
   Rf::AccountingRequest acr = Rf::AccountingRequest(_dict,
                                                     _real_stack,
-                                                    "session-id",
+                                                    "example-session-id",
                                                     "host.example.com",
                                                     "realm.example.com",
                                                     3u,
@@ -118,9 +118,6 @@ TEST_F(RfTest, CreateMessageTest)
   Diameter::Message msg = launder_message(acr);
   acr = Rf::AccountingRequest(msg);
 
-  printf("\n\nhi\n\n");
-  printf("acr: %s", acr.get_session_id().c_str());
-//  printf("sci: %s", acr.begin((Rf::Dictionary*)(acr.dict())->SERVICE_CONTEXT_ID)->val_str().c_str());
   delete body_doc;
 };
 


### PR DESCRIPTION
Completed bug fix.

Field has been added in.
Field: Service-Context-Id
Value: MNC.MCC.10.32260@3gpp.org

Have tested field is present and looks right by printing it out.

Fix to #262 
