### PR TITLE
[Reviewer: EM] Don't run Ralf if there is no Ralf hostname.

### DIFF
--- a/debian/ralf.init.d
+++ b/debian/ralf.init.d
@@ -153,11 +153,6 @@ do_start()
         #   1 if daemon was already running
         #   2 if daemon could not be started
 
-        # Exit if there is no ralf hostname configured
-        if [ -z "$ralf_hostname" ]; then
-          return 2
-        fi
-
         # Allow us to write to the pidfile directory
         install -m 755 -o $NAME -g root -d /var/run/$NAME && chown -R $NAME /var/run/$NAME
 

--- a/debian/ralf.init.d
+++ b/debian/ralf.init.d
@@ -153,6 +153,11 @@ do_start()
         #   1 if daemon was already running
         #   2 if daemon could not be started
 
+        # Exit if there is no ralf hostname configured
+        if [ -z "$ralf_hostname" ]; then
+          return 2
+        fi
+
         # Allow us to write to the pidfile directory
         install -m 755 -o $NAME -g root -d /var/run/$NAME && chown -R $NAME /var/run/$NAME
 

--- a/ralf.root/usr/share/clearwater/infrastructure/scripts/ralf.monit
+++ b/ralf.root/usr/share/clearwater/infrastructure/scripts/ralf.monit
@@ -25,8 +25,8 @@ if [ -z "$ralf_hostname" ]; then
 
 else
 
-# Set up the monit configuration for ralf with the right IP addresses and ports
-cat > /etc/monit/conf.d/ralf.monit <<EOF
+  # Set up the monit configuration for ralf with the right IP addresses and ports
+  cat > /etc/monit/conf.d/ralf.monit <<EOF
 # Check the Ralf process.
 
 # Monitor the service's PID file and memory use.
@@ -58,9 +58,10 @@ check program poll_ralf with path "/usr/share/clearwater/bin/poll_ralf.sh"
   # Aborting generates a core file and triggers diagnostic collection.
   if status != 0 for 2 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 2000.3; /etc/init.d/ralf abort'"
 EOF
-chmod 0644 /etc/monit/conf.d/ralf.monit
 
-# Force monit to reload its configuration
-reload clearwater-monit || true
+  chmod 0644 /etc/monit/conf.d/ralf.monit
+
+  # Force monit to reload its configuration
+  reload clearwater-monit || true
 
 fi

--- a/ralf.root/usr/share/clearwater/infrastructure/scripts/ralf.monit
+++ b/ralf.root/usr/share/clearwater/infrastructure/scripts/ralf.monit
@@ -11,6 +11,20 @@
 
 . /etc/clearwater/config
 
+if [ -z "$ralf_hostname" ]; then
+
+  if [ -f /etc/monit/conf.d/ralf.monit ]; then
+    rm /etc/monit/conf.d/ralf.monit
+
+    # Force monit to reload its configuration
+    reload clearwater-monit || true
+
+    # Stop ralf if it was running
+    service ralf stop
+  fi
+
+else
+
 # Set up the monit configuration for ralf with the right IP addresses and ports
 cat > /etc/monit/conf.d/ralf.monit <<EOF
 # Check the Ralf process.
@@ -48,3 +62,5 @@ chmod 0644 /etc/monit/conf.d/ralf.monit
 
 # Force monit to reload its configuration
 reload clearwater-monit || true
+
+fi

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -571,6 +571,13 @@ int main(int argc, char**argv)
     }
   }
 
+  // Check we've been provided with a hostname
+  if (options.ralf_hostname == "")
+  {
+    TRC_ERROR("No Ralf hostname provided - exiting");
+    return 1;
+  }
+
   // Parse the session-stores argument.
   std::string session_store_location;
   std::vector<std::string> remote_session_stores_locations;
@@ -775,7 +782,7 @@ int main(int argc, char**argv)
   std::string chronos_callback_addr = "127.0.0.1:" + port_str;
   int http_af = AF_INET;
 
-  if (options.chronos_hostname == "" || options.ralf_hostname == "")
+  if (options.chronos_hostname == "")
   {
     // If we are using a local chronos cluster, we want Chronos to call back to
     // its local Ralf instance so that we can handle Ralfs failing without missing


### PR DESCRIPTION
Ellie,

As discussed the other day, we'd like to be able to configured whether Ralf is enabled based on whether there is a configured host name. If it isn't enabled, we shouldn't start it or allow it to be started, and we shouldn't monitor it, or any of it's children.

To this end, I've made two changes:

- Add/remove the monit script based on whether Ralf is present
- Prevent Ralf from starting if there is no configured Ralf hostname