### PR TITLE
Optionally log Ralf HTTP bodies to SAS

### DIFF
--- a/debian/ralf.init.d
+++ b/debian/ralf.init.d
@@ -115,6 +115,7 @@ get_daemon_args()
         [ -z "$chronos_hostname" ] || chronos_hostname_arg="--chronos-hostname=$chronos_hostname"
         [ -z "$ralf_chronos_callback_uri" ] || ralf_chronos_callback_uri_arg="--ralf-chronos-callback-uri=$ralf_chronos_callback_uri"
         [ -z "$ralf_hostname" ] || ralf_hostname_arg="--ralf-hostname=$ralf_hostname"
+        [ -z "$http_acr_logging" ] || http_acr_logging_arg="--http-acr-logging"
 
         DAEMON_ARGS="--localhost=$local_ip
                      $local_site_name_arg
@@ -128,6 +129,7 @@ get_daemon_args()
                      $chronos_hostname_arg
                      $ralf_chronos_callback_uri_arg
                      $ralf_hostname_arg
+                     $http_acr_logging_arg
                      $billing_realm_arg
                      $billing_peer_arg
                      $target_latency_us_arg

--- a/include/handlers.hpp
+++ b/include/handlers.hpp
@@ -65,7 +65,8 @@ public:
     }
     else
     {
-      return &HttpStack::DEFAULT_SAS_LOGGER;
+      // TODO - Allow configuration to switch to DEFAULT_SAS_LOGGER
+      return &HttpStack::PRIVATE_SAS_LOGGER;
     }
   }
 };

--- a/include/handlers.hpp
+++ b/include/handlers.hpp
@@ -51,8 +51,9 @@ class BillingHandler:
   public HttpStackUtils::SpawningHandler<BillingTask, BillingHandlerConfig>
 {
 public:
-  BillingHandler(BillingHandlerConfig* cfg) :
-    SpawningHandler<BillingTask, BillingHandlerConfig>(cfg)
+  BillingHandler(BillingHandlerConfig* cfg, bool http_acr_logging) :
+    SpawningHandler<BillingTask, BillingHandlerConfig>(cfg),
+    _http_acr_logging(http_acr_logging)
   {}
   virtual ~BillingHandler() {}
 
@@ -65,10 +66,21 @@ public:
     }
     else
     {
-      // TODO - Allow configuration to switch to DEFAULT_SAS_LOGGER
-      return &HttpStack::PRIVATE_SAS_LOGGER;
+      if (_http_acr_logging)
+      {
+        // Include bodies in ACR HTTP messages logged to SAS.
+        return &HttpStack::DEFAULT_SAS_LOGGER;
+      }
+      else
+      {
+        // Ommit bodies from ACR HTTP messages logged to SAS.
+        return &HttpStack::PRIVATE_SAS_LOGGER;
+      }
     }
   }
+
+private:
+  bool _http_acr_logging;
 };
 
 #endif

--- a/include/handlers.hpp
+++ b/include/handlers.hpp
@@ -73,7 +73,9 @@ public:
       }
       else
       {
-        // Ommit bodies from ACR HTTP messages logged to SAS.
+        // Omit bodies from ACR HTTP messages logged to SAS.
+        // The private SAS logger does exactly this.  We aren't using it for
+        // privacy reasons, but it achieves the correct result.
         return &HttpStack::PRIVATE_SAS_LOGGER;
       }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,8 @@ enum OptionTypes
   DAEMON,
   CHRONOS_HOSTNAME,
   RALF_CHRONOS_CALLBACK_URI,
-  RALF_HOSTNAME
+  RALF_HOSTNAME,
+  HTTP_ACR_LOGGING
 };
 
 enum struct MemcachedWriteFormat

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,7 +141,7 @@ const static struct option long_opt[] =
   {"chronos-hostname",            required_argument, NULL, CHRONOS_HOSTNAME},
   {"ralf-chronos-callback-uri",   required_argument, NULL, RALF_CHRONOS_CALLBACK_URI},
   {"ralf-hostname",               required_argument, NULL, RALF_HOSTNAME},
-  {"http_acr_logging",            required_argument, NULL, HTTP_ACR_LOGGING},
+  {"http-acr-logging",            required_argument, NULL, HTTP_ACR_LOGGING},
   {NULL,                          0,                 NULL, 0},
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -214,7 +214,7 @@ void usage(void)
        "                            The hostname and port of the cluster of Ralf nodes to which this Ralf is\n"
        "                            a member. The port should be the HTTP port the nodes are listening on.\n"
        "                            This is used to form the callback URL for the Chronos cluser.\n"
-       "     --http_acr_logging     Whether to include the bodies of ACR HTTP requests when they are logged\n"
+       "     --http-acr-logging     Whether to include the bodies of ACR HTTP requests when they are logged\n"
        "                            to SAS\n"
        "     --pidfile=<filename>   Write pidfile\n"
        "     --daemon               Run as a daemon\n"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -104,6 +104,7 @@ struct options
   std::string chronos_hostname;
   std::string ralf_chronos_callback_uri;
   std::string ralf_hostname;
+  bool http_acr_logging;
 };
 
 const static struct option long_opt[] =
@@ -139,6 +140,7 @@ const static struct option long_opt[] =
   {"chronos-hostname",            required_argument, NULL, CHRONOS_HOSTNAME},
   {"ralf-chronos-callback-uri",   required_argument, NULL, RALF_CHRONOS_CALLBACK_URI},
   {"ralf-hostname",               required_argument, NULL, RALF_HOSTNAME},
+  {"http_acr_logging",            required_argument, NULL, HTTP_ACR_LOGGING},
   {NULL,                          0,                 NULL, 0},
 };
 
@@ -211,6 +213,8 @@ void usage(void)
        "                            The hostname and port of the cluster of Ralf nodes to which this Ralf is\n"
        "                            a member. The port should be the HTTP port the nodes are listening on.\n"
        "                            This is used to form the callback URL for the Chronos cluser.\n"
+       "     --http_acr_logging     Whether to include the bodies of ACR HTTP requests when they are logged\n"
+       "                            to SAS\n"
        "     --pidfile=<filename>   Write pidfile\n"
        "     --daemon               Run as a daemon\n"
        " -h, --help                 Show this help screen\n"
@@ -457,6 +461,10 @@ int init_options(int argc, char**argv, struct options& options)
 
     case RALF_HOSTNAME:
       options.ralf_hostname = std::string(optarg);
+      break;
+
+    case HTTP_ACR_LOGGING:
+      options.http_acr_logging = true;
       break;
 
     default:
@@ -847,7 +855,7 @@ int main(int argc, char**argv)
                                         access_logger,
                                         load_monitor);
   HttpStackUtils::PingHandler ping_handler;
-  BillingHandler billing_handler(cfg);
+  BillingHandler billing_handler(cfg, options.http_acr_logging);
   try
   {
     http_stack->initialize();


### PR DESCRIPTION
In order to reduce the volume of data logged to SAS, we've made the logging of Ralf HTTP bodies optional. By default, the bodies will not be logged (the messages appear in SAS with the generic string <Body present but not logged>).

If required, the parameter http_acr_logging=Y can be set in shared_config to turn this logging back on.

This PR covers the Ralf-side changes. There are some similar changes to Sprout - see [here](https://github.com/Metaswitch/sprout/pull/1845).