### PR TITLE
[Reviewer: EM] Set diameter timeout and add code coverage

### DIFF
--- a/debian/ralf.init.d
+++ b/debian/ralf.init.d
@@ -102,15 +102,6 @@ get_daemon_args()
           billing_realm_arg="--billing-realm=$home_domain"
         fi
 
-        # Default the diameter timeout to twice the target latency if not
-        # already overridden (rounding up).  Note that the former is expressed
-        # in milliseconds and the latter in microseconds, hence division by 500
-        # (i.e. multiplication by 2/1000).
-        if [ -z $diameter_timeout_ms ] && [ ! -z $target_latency_us ]
-        then
-          diameter_timeout_ms=$(( ($target_latency_us + 499)/500 ))
-        fi
-
         [ "$sas_use_signaling_interface" != "Y" ] || sas_signaling_if_arg="--sas-use-signaling-interface"
 
         [ -z "$diameter_timeout_ms" ] || diameter_timeout_ms_arg="--diameter-timeout-ms=$diameter_timeout_ms"

--- a/debian/ralf.init.d
+++ b/debian/ralf.init.d
@@ -102,8 +102,18 @@ get_daemon_args()
           billing_realm_arg="--billing-realm=$home_domain"
         fi
 
+        # Default the diameter timeout to twice the target latency if not
+        # already overridden (rounding up).  Note that the former is expressed
+        # in milliseconds and the latter in microseconds, hence division by 500
+        # (i.e. multiplication by 2/1000).
+        if [ -z $diameter_timeout_ms ] && [ ! -z $target_latency_us ]
+        then
+          diameter_timeout_ms=$(( ($target_latency_us + 499)/500 ))
+        fi
+
         [ "$sas_use_signaling_interface" != "Y" ] || sas_signaling_if_arg="--sas-use-signaling-interface"
 
+        [ -z "$diameter_timeout_ms" ] || diameter_timeout_ms_arg="--diameter-timeout-ms=$diameter_timeout_ms"
         [ -z "$target_latency_us" ] || target_latency_us_arg="--target-latency-us=$target_latency_us"
         [ -z "$max_tokens" ] || max_tokens_arg="--max-tokens=$max_tokens"
         [ -z "$init_token_rate" ] || init_token_rate_arg="--init-token-rate=$init_token_rate"
@@ -132,6 +142,7 @@ get_daemon_args()
                      $http_acr_logging_arg
                      $billing_realm_arg
                      $billing_peer_arg
+                     $diameter_timeout_ms_arg
                      $target_latency_us_arg
                      $max_tokens_arg
                      $init_token_rate_arg

--- a/include/peer_message_sender.hpp
+++ b/include/peer_message_sender.hpp
@@ -24,7 +24,9 @@
 class PeerMessageSender
 {
 public:
-  PeerMessageSender(SAS::TrailId trail, const std::string& dest_realm);
+  PeerMessageSender(SAS::TrailId trail,
+                    const std::string& dest_realm,
+                    const int diameter_timeout);
   virtual ~PeerMessageSender();
   virtual void send(Message* msg,
                     SessionManager* sm,
@@ -44,6 +46,7 @@ private:
   Diameter::Stack* _diameter_stack;
   SAS::TrailId _trail;
   const std::string _dest_realm;
+  const int _diameter_timeout;
 };
 
 #endif /* PEER_MESSAGE_SENDER_HPP_ */

--- a/include/peer_message_sender_factory.hpp
+++ b/include/peer_message_sender_factory.hpp
@@ -16,17 +16,22 @@
 class PeerMessageSenderFactory
 {
 public:
-  PeerMessageSenderFactory(const std::string& dest_realm) : _dest_realm(dest_realm) {};
+  PeerMessageSenderFactory(const std::string& dest_realm,
+                           const int diameter_timeout) :
+    _dest_realm(dest_realm),
+    _diameter_timeout(diameter_timeout)
+  {};
 
   virtual ~PeerMessageSenderFactory() {};
 
   virtual PeerMessageSender* newSender(SAS::TrailId trail)
   {
-    return new PeerMessageSender(trail, _dest_realm);
+    return new PeerMessageSender(trail, _dest_realm, _diameter_timeout);
   }
 
 private:
   const std::string _dest_realm;
+  const int _diameter_timeout;
 };
 
 

--- a/include/peer_message_sender_factory.hpp
+++ b/include/peer_message_sender_factory.hpp
@@ -18,6 +18,8 @@ class PeerMessageSenderFactory
 public:
   PeerMessageSenderFactory(const std::string& dest_realm) : _dest_realm(dest_realm) {};
 
+  virtual ~PeerMessageSenderFactory() {};
+
   virtual PeerMessageSender* newSender(SAS::TrailId trail)
   {
     return new PeerMessageSender(trail, _dest_realm);

--- a/include/rf.h
+++ b/include/rf.h
@@ -73,7 +73,10 @@ public:
 class AccountingResponse : public Diameter::Message
 {
 public:
-  AccountingResponse(const Dictionary* dict, Diameter::Stack* diameter_stack);
+  AccountingResponse(const Dictionary* dict,
+                     Diameter::Stack* diameter_stack,
+                     const int32_t& result_code,
+                     const std::string& session_id);
   inline AccountingResponse(Diameter::Message& msg) : Diameter::Message(msg) {};
   ~AccountingResponse();
 };

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -18,14 +18,12 @@
 #include "rapidjson/prettywriter.h"
 #include "rapidjson/stringbuffer.h"
 
-//LCOV_EXCL_START
-// We don't want to actually run the handlers
-
 void BillingTask::run()
 {
   if (_req.method() != htp_method_POST)
   {
     send_http_reply(405);
+    delete this;
     return;
   }
 
@@ -70,7 +68,6 @@ void BillingTask::run()
 
   delete this;
 }
-//LCOV_EXCL_STOP
 
 HTTPCode BillingTask::parse_body(std::string call_id,
                                  bool timer_interim,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,6 +44,7 @@ enum OptionTypes
   DNS_SERVER=256+1,
   MEMCACHED_WRITE_FORMAT,
   TARGET_LATENCY_US,
+  DIAMETER_TIMEOUT_MS,
   MAX_TOKENS,
   INIT_TOKEN_RATE,
   MIN_TOKEN_RATE,
@@ -91,6 +92,7 @@ struct options
   std::string sas_system_name;
   MemcachedWriteFormat memcached_write_format;
   int target_latency_us;
+  int diameter_timeout_ms;
   int max_tokens;
   float init_token_rate;
   float min_token_rate;
@@ -127,6 +129,7 @@ const static struct option long_opt[] =
   {"help",                        no_argument,       NULL, 'h'},
   {"memcached-write-format",      required_argument, 0,    MEMCACHED_WRITE_FORMAT},
   {"target-latency-us",           required_argument, NULL, TARGET_LATENCY_US},
+  {"diameter-timeout-ms",         required_argument, NULL, DIAMETER_TIMEOUT_MS},
   {"max-tokens",                  required_argument, NULL, MAX_TOKENS},
   {"init-token-rate",             required_argument, NULL, INIT_TOKEN_RATE},
   {"min-token-rate",              required_argument, NULL, MIN_TOKEN_RATE},
@@ -388,6 +391,11 @@ int init_options(int argc, char**argv, struct options& options)
       }
       break;
 
+    case DIAMETER_TIMEOUT_MS:
+      TRC_INFO("Diameter timeout: %s", optarg);
+      options.diameter_timeout_ms = atoi(optarg);
+      break;
+
     case MAX_TOKENS:
       options.max_tokens = atoi(optarg);
       if (options.max_tokens <= 0)
@@ -536,6 +544,7 @@ int main(int argc, char**argv)
   options.sas_system_name = "";
   options.memcached_write_format = MemcachedWriteFormat::JSON;
   options.target_latency_us = 100000;
+  options.diameter_timeout_ms = 200;
   options.max_tokens = 1000;
   options.init_token_rate = 100.0;
   options.min_token_rate = 10.0;
@@ -794,7 +803,8 @@ int main(int argc, char**argv)
   }
 
   BillingHandlerConfig* cfg = new BillingHandlerConfig();
-  PeerMessageSenderFactory* factory = new PeerMessageSenderFactory(options.billing_realm);
+  PeerMessageSenderFactory* factory = new PeerMessageSenderFactory(options.billing_realm,
+                                                                   options.diameter_timeout_ms);
 
   // Create a connection to Chronos.
   std::string port_str = std::to_string(options.http_port);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -186,6 +186,8 @@ void usage(void)
        "                            (defaults to 'json')\n"
        "     --target-latency-us <usecs>\n"
        "                            Target latency above which throttling applies (default: 100000)\n"
+       "     --diameter-timeout <milliseconds>\n"
+       "                            Length of time (in ms) before timing out a Diameter request to the CDF\n"
        "     --max-tokens N         Maximum number of tokens allowed in the token bucket (used by\n"
        "                            the throttling code (default: 1000))\n"
        "     --dns-timeout <milliseconds>\n"
@@ -261,6 +263,7 @@ int init_options(int argc, char**argv, struct options& options)
 {
   int opt;
   int long_opt_ind;
+  bool diameter_timeout_set = false;
 
   optind = 0;
   while ((opt = getopt_long(argc, argv, options_description.c_str(), long_opt, &long_opt_ind)) != -1)
@@ -393,6 +396,7 @@ int init_options(int argc, char**argv, struct options& options)
 
     case DIAMETER_TIMEOUT_MS:
       TRC_INFO("Diameter timeout: %s", optarg);
+      diameter_timeout_set = true;
       options.diameter_timeout_ms = atoi(optarg);
       break;
 
@@ -481,6 +485,12 @@ int init_options(int argc, char**argv, struct options& options)
       TRC_ERROR("Unknown option: %d.  Run with --help for options.", opt);
       return -1;
     }
+  }
+
+  if (!diameter_timeout_set)
+  {
+    Utils::calculate_diameter_timeout(options.target_latency_us,
+                                      options.diameter_timeout_ms);
   }
 
   return 0;

--- a/src/peer_message_sender.cpp
+++ b/src/peer_message_sender.cpp
@@ -24,10 +24,13 @@
  *
  *   No action should be taken after any of the above happens, as the this pointer becomes invalid.
  */
-PeerMessageSender::PeerMessageSender(SAS::TrailId trail, const std::string& dest_realm) :
+PeerMessageSender::PeerMessageSender(SAS::TrailId trail,
+                                     const std::string& dest_realm,
+                                     const int diameter_timeout) :
   _which(0),
   _trail(trail),
-  _dest_realm(dest_realm)
+  _dest_realm(dest_realm),
+  _diameter_timeout(diameter_timeout)
 {
 }
 
@@ -75,7 +78,7 @@ void PeerMessageSender::int_send_msg()
   // Send the message to freeDiameter.  This object could get modified by a
   // callback (including being deleted) so is not safe to reference after this
   // point.
-  acr.send(tsx); return;
+  acr.send(tsx, _diameter_timeout); return;
 }
 
 /* Called when a message has been sent and a response has been received.

--- a/src/rf.cpp
+++ b/src/rf.cpp
@@ -119,10 +119,21 @@ AccountingRequest::~AccountingRequest()
 }
 
 AccountingResponse::AccountingResponse(const Dictionary* dict,
-                                       Diameter::Stack* diameter_stack) :
+                                       Diameter::Stack* diameter_stack,
+                                       const int32_t& result_code,
+                                       const std::string& session_id) :
     Diameter::Message(dict, dict->ACCOUNTING_RESPONSE, diameter_stack)
 {
   TRC_DEBUG("Building an Accounting-Response");
+  if (result_code)
+  {
+    add(Diameter::AVP(dict->RESULT_CODE).val_i32(result_code));
+  }
+
+  if (session_id != "")
+  {
+    add_session_id(session_id);
+  }
 }
 
 AccountingResponse::~AccountingResponse()

--- a/src/session_manager.cpp
+++ b/src/session_manager.cpp
@@ -387,6 +387,7 @@ void SessionManager::on_ccf_response(bool accepted,
   else
   {
     TRC_WARNING("Session for %s received error (%d) from CDF", msg->call_id.c_str(), rc);
+
     if (msg->record_type.isInterim())
     {
       if (rc == 5002)

--- a/src/session_manager.cpp
+++ b/src/session_manager.cpp
@@ -386,7 +386,7 @@ void SessionManager::on_ccf_response(bool accepted,
   }
   else
   {
-    TRC_WARNING("Session for %s received error from CDF", msg->call_id.c_str());
+    TRC_WARNING("Session for %s received error (%d) from CDF", msg->call_id.c_str(), rc);
     if (msg->record_type.isInterim())
     {
       if (rc == 5002)

--- a/src/ut/coverage-not-yet
+++ b/src/ut/coverage-not-yet
@@ -1,5 +1,3 @@
-# The following files do not have full code coverage yet, because they need the freeDiameter stack to be mocked out.
+# The following files do not have full code coverage yet.
 
-ralf_transaction.cpp
 rf.cpp
-peer_message_sender.cpp

--- a/src/ut/test_handlers.cpp
+++ b/src/ut/test_handlers.cpp
@@ -134,7 +134,7 @@ class HandlerTest : public ::testing::Test
 
     std::string body = "{\"peers\": {\"ccf\": [\"ec2-54-197-167-141.compute-1.amazonaws.com\"]}, \"event\": {\"Accounting-Record-Type\": " + std::to_string(record_type) +", \"Acct-Interim-Interval\": 300, \"Service-Information\": {\"IMS-Information\": {\"Role-Of-Node\": 0, \"Node-Functionality\": 0}}}}";
 
-    // Send in a mock HTTP resuest.
+    // Send in a mock HTTP request.
     MockHttpStack::Request req(_httpstack,
                                "/call-id/" + CALL_ID,
                                "",
@@ -175,14 +175,13 @@ class HandlerTest : public ::testing::Test
     if (multiple_peers)
     {
       body = "{\"peers\": {\"ccf\": [\"ec2-54-197-167-141.compute-1.amazonaws.com\", \"ec2-34-189-147-119.compute-1.amazonaws.com\"]}, \"event\": {\"Accounting-Record-Type\": 1, \"Acct-Interim-Interval\": 300, \"Service-Information\": {\"IMS-Information\": {\"Role-Of-Node\": 0, \"Node-Functionality\": 0}}}}";
-
     }
     else
     {
       body = "{\"peers\": {\"ccf\": [\"ec2-54-197-167-141.compute-1.amazonaws.com\"]}, \"event\": {\"Accounting-Record-Type\": 1, \"Acct-Interim-Interval\": 300, \"Service-Information\": {\"IMS-Information\": {\"Role-Of-Node\": 0, \"Node-Functionality\": 0}}}}";
     }
 
-    // Send in a mock HTTP resuest.
+    // Send in a mock HTTP request.
     MockHttpStack::Request req(_httpstack,
                                "/call-id/" + CALL_ID,
                                "",
@@ -360,11 +359,12 @@ TEST_F(HandlerTest, NoNodeFunctionalityTest)
   delete msg; msg = NULL;
 };
 
+// Tests that Non POST HTTP requests are rejected with a 405.
 TEST_F(HandlerTest, NotPost)
 {
   std::string body = "{\"peers\": {\"ccf\": [\"ec2-54-197-167-141.compute-1.amazonaws.com\"]}, \"event\": {\"Accounting-Record-Type\": 1, \"Acct-Interim-Interval\": 300, \"Service-Information\": {\"IMS-Information\": {\"Role-Of-Node\": 0, \"Node-Functionality\": 0}}}}";
 
-  // Send in a mock HTTP resuest. It's not a POST so should be rejected with a
+  // Send in a mock HTTP request. It's not a POST so should be rejected with a
   // 405 response.
   MockHttpStack::Request req(_httpstack,
                              "/call-id/skdlfjsdkf",
@@ -382,11 +382,12 @@ TEST_F(HandlerTest, NotPost)
   task->run();
 }
 
+// Tests that a request with a bad JSON body is rejected with a 405.
 TEST_F(HandlerTest, BadBody)
 {
   std::string body = "{\"peers\": {\"ccf\": [\"ec2-54-197-167-141.compute-1.amazonaws.com\"]}, \"event\": {\"Accounting-Record-Type\": 1, \"Acct-Interim-Interval\": 300, \"Service-Information\": {\"IMS-Information\": {\"Role-Of-Node\": 0, \"Node-Functionality\": 0}}}";
 
-  // Send in a mock HTTP resuest. The body is invalid JSON so it should trigger
+  // Send in a mock HTTP request. The body is invalid JSON so it should trigger
   // a 405 response.
   MockHttpStack::Request req(_httpstack,
                              "/call-id/" + CALL_ID,
@@ -404,11 +405,13 @@ TEST_F(HandlerTest, BadBody)
   task->run();
 }
 
+// Tests that a simple EVENT ACR is handled.
 TEST_F(HandlerTest, SimpleMainline)
 {
   request_response_template(2001, EVENT, false);
 }
 
+// Tests that a sequence of START, INTERIM, and STOP ACRs are handled.
 TEST_F(HandlerTest, SimpleDialog)
 {
   request_response_template(2001, START, false);
@@ -416,28 +419,33 @@ TEST_F(HandlerTest, SimpleDialog)
   request_response_template(2001, STOP, true);
 }
 
+// Tests a failure flow where the CDF sends a negative response to an INTERIM.
 TEST_F(HandlerTest, FailedDialog)
 {
   request_response_template(2001, START, false);
   request_response_template(3002, INTERIM, true);
 }
 
+// Tests a failure flow where the CDF sends a 5002 response to an INTERIM.
 TEST_F(HandlerTest, FailedDialog5002)
 {
   request_response_template(2001, START, false);
   request_response_template(5002, INTERIM, true);
 }
 
+// Tests a request that fails to be delivered to the CDF.
 TEST_F(HandlerTest, DeliveryFailed)
 {
   request_response_template(3002, EVENT, false);
 }
 
+// Tests a request that times out before a response is sent by the CDF.
 TEST_F(HandlerTest, Timeout)
 {
   request_timeout_template(false);
 }
 
+// Another timeout test where the request is retried to a second peer.
 TEST_F(HandlerTest, TimeoutMultiplePeers)
 {
   request_timeout_template(true);

--- a/src/ut/test_handlers.cpp
+++ b/src/ut/test_handlers.cpp
@@ -13,11 +13,43 @@
 #include "message.hpp"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "test_utils.hpp"
+
+#include "mockdiameterstack.hpp"
+#include "mockhttpstack.hpp"
+#include "mock_health_checker.hpp"
+#include "localstore.h"
+#include "fakechronosconnection.cpp"
+#include "session_store.h"
+#include "peer_message_sender_factory.hpp"
+
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::WithArgs;
+using ::testing::An;
 
 static const SAS::TrailId FAKE_TRAIL_ID = 0;
+static const std::string CALL_ID = "abc123";
 
 class HandlerTest : public ::testing::Test
 {
+  static Diameter::Stack* _real_stack;
+  static MockDiameterStack* _mock_stack;
+  static MockHttpStack* _httpstack;
+  static SessionManager* _mgr;
+  static BillingHandlerConfig* _cfg;
+  static LocalStore* _local_data_store;
+  static SessionStore* _local_session_store;
+  static LocalStore* _remote_data_store;
+  static SessionStore* _remote_session_store;
+  static FakeChronosConnection* _chronos_connection;
+  static MockHealthChecker* _hc;
+  static PeerMessageSenderFactory* _factory;
+  static Rf::Dictionary* _dict;
+
+  static struct msg* _caught_fd_msg;
+  static Diameter::Transaction* _caught_diam_tsx;
+
   HandlerTest()
   {
   }
@@ -25,7 +57,182 @@ class HandlerTest : public ::testing::Test
   virtual ~HandlerTest()
   {
   }
+
+  static void SetUpTestCase()
+  {
+    _real_stack = Diameter::Stack::get_instance();
+    _real_stack->initialize();
+    _real_stack->configure(UT_DIR + "/diameterstack.conf", NULL);
+
+    _mock_stack = new MockDiameterStack();
+    _httpstack = new MockHttpStack();
+    _cfg = new BillingHandlerConfig();
+    _local_data_store = new LocalStore();
+    _local_session_store = new SessionStore(_local_data_store);
+    _remote_data_store = new LocalStore();
+    _remote_session_store = new SessionStore(_remote_data_store);
+    _dict = new Rf::Dictionary();
+    _factory = new PeerMessageSenderFactory("example.com");
+    _chronos_connection = new FakeChronosConnection();
+    _hc = new MockHealthChecker();
+    _mgr = new SessionManager(_local_session_store, { _remote_session_store }, _dict, _factory, _chronos_connection, _mock_stack, _hc);
+    _cfg->mgr = _mgr;
+  }
+
+  static void TearDownTestCase()
+  {
+    _real_stack->stop();
+    _real_stack->wait_stopped();
+
+    delete _mock_stack; _mock_stack = NULL;
+    delete _httpstack; _httpstack = NULL;
+    delete _mgr, _mgr = NULL;
+    delete _cfg, _cfg = NULL;
+    delete _local_data_store; _local_data_store = NULL;
+    delete _local_session_store; _local_session_store = NULL;
+    delete _remote_data_store; _remote_data_store = NULL;
+    delete _remote_session_store; _remote_session_store = NULL;
+    delete _chronos_connection; _chronos_connection = NULL;
+    delete _hc; _hc = NULL;
+    delete _dict; _dict = NULL;
+    delete _factory; _factory = NULL;
+  }
+
+  void TearDown()
+  {
+    if (_caught_diam_tsx != NULL)
+    {
+      delete _caught_diam_tsx; _caught_diam_tsx = NULL;
+    }
+  }
+
+  static void store_msg_tsx(struct msg* msg, Diameter::Transaction* tsx)
+  {
+    if (_caught_diam_tsx != NULL)
+    {
+      delete _caught_diam_tsx; _caught_diam_tsx = NULL;
+    }
+
+    _caught_fd_msg = msg;
+    _caught_diam_tsx = tsx;
+  }
+
+  void request_response_template(int result_code,
+                                 bool timer_interim)
+  {
+    std::string query = "";
+    if (timer_interim)
+    {
+      query += "?timer-interim=true";
+    }
+
+    std::string body = "{\"peers\": {\"ccf\": [\"ec2-54-197-167-141.compute-1.amazonaws.com\"]}, \"event\": {\"Accounting-Record-Type\": 1, \"Acct-Interim-Interval\": 300, \"Service-Information\": {\"IMS-Information\": {\"Role-Of-Node\": 0, \"Node-Functionality\": 0}}}}";
+
+    // Send in a mock HTTP resuest.
+    MockHttpStack::Request req(_httpstack,
+                               "/call-id/" + CALL_ID,
+                               "",
+                               query,
+                               body,
+                               htp_method_POST);
+
+    BillingTask* task = new BillingTask(req,
+                                        _cfg,
+                                        FAKE_TRAIL_ID);
+
+    // Running the handler should trigger an HTTP response and a Diameter
+    // request.
+    EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
+    EXPECT_CALL(*_mock_stack, send(_, An<Diameter::Transaction*>()))
+      .Times(1)
+      .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));;
+    task->run();
+
+    Rf::AccountingResponse aca(_dict,
+                               _mock_stack,
+                               result_code,
+                               CALL_ID);
+
+    // Send in a response.
+    if (result_code == 2001)
+    {
+      EXPECT_CALL(*_hc, health_check_passed());
+    }
+
+    fd_msg_free(_caught_fd_msg); _caught_fd_msg = NULL;
+    _caught_diam_tsx->on_response(aca);
+  }
+
+  void request_timeout_template(bool multiple_peers)
+  {
+    std::string body;
+    if (multiple_peers)
+    {
+      body = "{\"peers\": {\"ccf\": [\"ec2-54-197-167-141.compute-1.amazonaws.com\", \"ec2-34-189-147-119.compute-1.amazonaws.com\"]}, \"event\": {\"Accounting-Record-Type\": 1, \"Acct-Interim-Interval\": 300, \"Service-Information\": {\"IMS-Information\": {\"Role-Of-Node\": 0, \"Node-Functionality\": 0}}}}";
+
+    }
+    else
+    {
+      body = "{\"peers\": {\"ccf\": [\"ec2-54-197-167-141.compute-1.amazonaws.com\"]}, \"event\": {\"Accounting-Record-Type\": 1, \"Acct-Interim-Interval\": 300, \"Service-Information\": {\"IMS-Information\": {\"Role-Of-Node\": 0, \"Node-Functionality\": 0}}}}";
+    }
+
+    // Send in a mock HTTP resuest.
+    MockHttpStack::Request req(_httpstack,
+                               "/call-id/" + CALL_ID,
+                               "",
+                               "",
+                               body,
+                               htp_method_POST);
+
+    BillingTask* task = new BillingTask(req,
+                                        _cfg,
+                                        FAKE_TRAIL_ID);
+
+    // Running the handler should trigger an HTTP response and a Diameter
+    // request.
+    EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
+    EXPECT_CALL(*_mock_stack, send(_, An<Diameter::Transaction*>()))
+      .Times(1)
+      .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));;
+    task->run();
+
+    // If we have multiple peers, expect a retransmission when we time out the
+    // first request.
+    if (multiple_peers)
+    {
+      EXPECT_CALL(*_mock_stack, send(_, An<Diameter::Transaction*>()))
+        .Times(1)
+        .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));;
+    }
+
+    fd_msg_free(_caught_fd_msg); _caught_fd_msg = NULL;
+    _caught_diam_tsx->on_timeout();
+
+    if (multiple_peers)
+    {
+      // Time out the retransmission.
+      fd_msg_free(_caught_fd_msg); _caught_fd_msg = NULL;
+      _caught_diam_tsx->on_timeout();
+    }
+  }
 };
+
+Diameter::Stack* HandlerTest::_real_stack;
+MockDiameterStack* HandlerTest::_mock_stack = NULL;
+MockHttpStack* HandlerTest::_httpstack = NULL;
+SessionManager* HandlerTest::_mgr = NULL;
+BillingHandlerConfig* HandlerTest::_cfg = NULL;
+LocalStore* HandlerTest::_local_data_store = NULL;
+SessionStore* HandlerTest::_local_session_store;
+LocalStore* HandlerTest::_remote_data_store = NULL;
+SessionStore* HandlerTest::_remote_session_store;
+FakeChronosConnection* HandlerTest::_chronos_connection = NULL;
+MockHealthChecker* HandlerTest::_hc = NULL;
+Rf::Dictionary* HandlerTest::_dict = NULL;
+PeerMessageSenderFactory* HandlerTest::_factory = NULL;
+
+struct msg* HandlerTest::_caught_fd_msg;
+Diameter::Transaction* HandlerTest::_caught_diam_tsx;
 
 TEST_F(HandlerTest, GoodJSONTest)
 {
@@ -146,3 +353,72 @@ TEST_F(HandlerTest, NoNodeFunctionalityTest)
   ASSERT_EQ(NULL, msg);
   delete msg; msg = NULL;
 };
+
+TEST_F(HandlerTest, NotPost)
+{
+  std::string body = "{\"peers\": {\"ccf\": [\"ec2-54-197-167-141.compute-1.amazonaws.com\"]}, \"event\": {\"Accounting-Record-Type\": 1, \"Acct-Interim-Interval\": 300, \"Service-Information\": {\"IMS-Information\": {\"Role-Of-Node\": 0, \"Node-Functionality\": 0}}}}";
+
+  // Send in a mock HTTP resuest. It's not a POST so should be rejected with a
+  // 405 response.
+  MockHttpStack::Request req(_httpstack,
+                             "/call-id/skdlfjsdkf",
+                             "",
+                             "",
+                             body,
+                             htp_method_PUT);
+
+  BillingTask* task = new BillingTask(req,
+                                      _cfg,
+                                      FAKE_TRAIL_ID);
+
+  // Running the handler should trigger an 405 HTTP response.
+  EXPECT_CALL(*_httpstack, send_reply(_,405, _));
+  task->run();
+}
+
+TEST_F(HandlerTest, BadBody)
+{
+  std::string body = "{\"peers\": {\"ccf\": [\"ec2-54-197-167-141.compute-1.amazonaws.com\"]}, \"event\": {\"Accounting-Record-Type\": 1, \"Acct-Interim-Interval\": 300, \"Service-Information\": {\"IMS-Information\": {\"Role-Of-Node\": 0, \"Node-Functionality\": 0}}}";
+
+  // Send in a mock HTTP resuest. The body is invalid JSON so it should trigger
+  // a 405 response.
+  MockHttpStack::Request req(_httpstack,
+                             "/call-id/" + CALL_ID,
+                             "",
+                             "",
+                             body,
+                             htp_method_POST);
+
+  BillingTask* task = new BillingTask(req,
+                                      _cfg,
+                                      FAKE_TRAIL_ID);
+
+  // Running the handler should trigger a 405 HTTP response.
+  EXPECT_CALL(*_httpstack, send_reply(_, 400, _));
+  task->run();
+}
+
+TEST_F(HandlerTest, SimpleMainline)
+{
+  request_response_template(2001, false);
+}
+
+TEST_F(HandlerTest, SimpleInterim)
+{
+  request_response_template(2001, true);
+}
+
+TEST_F(HandlerTest, DeliveryFailed)
+{
+  request_response_template(3002, false);
+}
+
+TEST_F(HandlerTest, Timeout)
+{
+  request_timeout_template(false);
+}
+
+TEST_F(HandlerTest, TimeoutMultiplePeers)
+{
+  request_timeout_template(true);
+}

--- a/src/ut/test_handlers.cpp
+++ b/src/ut/test_handlers.cpp
@@ -77,7 +77,7 @@ class HandlerTest : public ::testing::Test
     _remote_data_store = new LocalStore();
     _remote_session_store = new SessionStore(_remote_data_store);
     _dict = new Rf::Dictionary();
-    _factory = new PeerMessageSenderFactory("example.com");
+    _factory = new PeerMessageSenderFactory("example.com", 200);
     _chronos_connection = new FakeChronosConnection();
     _hc = new MockHealthChecker();
     _mgr = new SessionManager(_local_session_store, { _remote_session_store }, _dict, _factory, _chronos_connection, _mock_stack, _hc);
@@ -149,7 +149,7 @@ class HandlerTest : public ::testing::Test
     // Running the handler should trigger an HTTP response and a Diameter
     // request.
     EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
-    EXPECT_CALL(*_mock_stack, send(_, An<Diameter::Transaction*>()))
+    EXPECT_CALL(*_mock_stack, send(_, An<Diameter::Transaction*>(), 200))
       .Times(1)
       .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));;
     task->run();
@@ -197,7 +197,7 @@ class HandlerTest : public ::testing::Test
     // Running the handler should trigger an HTTP response and a Diameter
     // request.
     EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
-    EXPECT_CALL(*_mock_stack, send(_, An<Diameter::Transaction*>()))
+    EXPECT_CALL(*_mock_stack, send(_, An<Diameter::Transaction*>(), 200))
       .Times(1)
       .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));;
     task->run();
@@ -206,7 +206,7 @@ class HandlerTest : public ::testing::Test
     // first request.
     if (multiple_peers)
     {
-      EXPECT_CALL(*_mock_stack, send(_, An<Diameter::Transaction*>()))
+      EXPECT_CALL(*_mock_stack, send(_, An<Diameter::Transaction*>(), 200))
         .Times(1)
         .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));;
     }


### PR DESCRIPTION
This PR:
 - Sets a diameter timeout so that we don't leak memory if the CCF is unresponsive. I've copied code from homestead so that we set the same defaults if the diameter timeout config option is not set.
 - Adds UTs to get code coverage in most of Ralf.