### PR TITLE
Improve SAS command line option logging

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -297,6 +297,7 @@ int init_options(int argc, char**argv, struct options& options)
     {
       std::vector<std::string> sas_options;
       Utils::split_string(std::string(optarg), ',', sas_options, 0, false);
+
       if ((sas_options.size() == 2) &&
           !sas_options[0].empty() &&
           !sas_options[1].empty())
@@ -305,6 +306,10 @@ int init_options(int argc, char**argv, struct options& options)
         options.sas_system_name = sas_options[1];
         TRC_INFO("SAS set to %s", options.sas_server.c_str());
         TRC_INFO("System name is set to %s", options.sas_system_name.c_str());
+      }
+      else
+      {
+        TRC_WARNING("Invalid SAS option: %s", optarg);
       }
     }
     break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -309,7 +309,7 @@ int init_options(int argc, char**argv, struct options& options)
       }
       else
       {
-        TRC_WARNING("Invalid SAS option: %s", optarg);
+        TRC_WARNING("Invalid --sas option: %s", optarg);
       }
     }
     break;


### PR DESCRIPTION
The handling of the SAS command line option is inconsistent between components, and does not log when an invalid option is passed. This change makes the handling consistent and adds an invalid option log.

The change passes the unit tests.