### PR TITLE
Reduce Diameter watchdog timer default value from 30 seconds to 6

### DIFF
--- a/ralf.root/usr/share/clearwater/infrastructure/scripts/ralf
+++ b/ralf.root/usr/share/clearwater/infrastructure/scripts/ralf
@@ -13,7 +13,7 @@ ralf_listen_port=3869
 ralf_secure_listen_port=5659
 acl_required=false
 check_destination_host=true
-ralf_diameter_watchdog_timer=30
+ralf_diameter_watchdog_timer=6
 . /etc/clearwater/config
 
 # Allow a specific FQDN for Ralf to be set (in case this is an


### PR DESCRIPTION
Reduces the default value of the ralf_diameter_watchdog_timer option from the freeDiameter default value of 30 seconds to the minimum value of 6, bringing it into line with the corresponding option in homestead.